### PR TITLE
Switch to MongoSandbox8 for testing

### DIFF
--- a/Verify.MongoDB.Tests/IntegrationTests.cs
+++ b/Verify.MongoDB.Tests/IntegrationTests.cs
@@ -1,6 +1,6 @@
-using EphemeralMongo;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoSandbox;
 
 namespace Verify.MongoDB.Tests;
 

--- a/Verify.MongoDB.Tests/Verify.MongoDB.Tests.csproj
+++ b/Verify.MongoDB.Tests/Verify.MongoDB.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="EphemeralMongo6" Version="1.1.3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="MongoSandbox8" Version="1.0.1" />
 		<PackageReference Include="Verify.Xunit" Version="26.6.0" />
 		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">

--- a/Verify.MongoDB/Verify.MongoDB.csproj
+++ b/Verify.MongoDB/Verify.MongoDB.csproj
@@ -19,8 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <!-- Stick with MongoDB.Driver 2.5.0 so we work with that and above -->
-      <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+      <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
       <PackageReference Include="Verify" Version="26.6.0" />
 	</ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.0",
+  "version": "5.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
- The old EphemeralMongo package appears to be abandoned.
- GitHub Actions runners are now running Ubuntu 24.04 which appears to be incompatible with Mongo 6.
- https://github.com/wassim-k/MongoSandbox is an updated fork of EphemeralMongo, but it requires that you use at least MongoDB.Driver v3.
- Upgrade to MongoDB.Driver 3.1.0